### PR TITLE
Add YouTube API key to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # YouTube API配置
-YOUTUBE_API_KEY=your_youtube_api_key_here
+YOUTUBE_API_KEY=AIzaSyAaRU2heoQSXlxgNxQQp-FrxwKxrLJ4PCA
 YOUTUBE_CLIENT_ID=your_youtube_client_id_here
 YOUTUBE_CLIENT_SECRET=your_youtube_client_secret_here
 


### PR DESCRIPTION
## Summary
- update `.env.example` with the provided YouTube API key so deployments have the key by default

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6879cc9a5b488326a4467c58f28accdd